### PR TITLE
add more details in API reference for both sync and async endpoints

### DIFF
--- a/api-reference/async-endpoints.mdx
+++ b/api-reference/async-endpoints.mdx
@@ -1,0 +1,32 @@
+---
+title: 'Async API Endpoints'
+description: 'API Reference for the asynchronous functions of the AnyParser API'
+---
+
+## Overview
+The `AnyParser` API has asynchronous endpoints for its parsing and extraction features. These are asynchronous endpoints that will return a file ID. You can use this file ID to fetch the results of the extraction at a later time. Consider using if you have longer or more complex files. These async endpoints have a timeout of 180 seconds.
+
+There are 2 async endpoints:
+| Endpoint        | Description                                       |
+|-----------------|---------------------------------------------------|
+| [/async/upload](/api-reference/endpoint/upload)      | Upload the file to process and the process type. Returns the file ID. |
+| [/async/fetch](/api-reference/endpoint/fetch)  | Poll the results for a file ID.     |
+
+Generally, for all async requests, you would upload a file via the `/async/upload` endpoint, get its file_id, and then poll the `/async/fetch` endpoint to get the result.
+
+## /async/upload
+This endpoint is used to upload a file with a specified `process_type` and get a file ID.
+
+You can specify the following for the `process_type`:
+| process_type        | Description                                       |
+|-----------------|---------------------------------------------------|
+| `file` | This is the Default. It parses the full content from a file. This has the same functionality as the [full-content-parse](/sdk-reference/full-content-parse) in the SDK |
+| `json` | This extracts key-value pairs from the document. This has the same functionality as the [key-value extraction](/sdk-reference/key-value-extraction) in the SDK |
+
+For more details on how to call this endpoint see the [Async Upload Endpoint Example](/api-reference/endpoint/async-upload).
+
+## /async/fetch
+Once you have retrieved the `file_id` from the `/async/upload` endpoint, you then send that `file_id` to the `/async/fetch` endpoint to retrieve the result.
+
+For more details on how to call this endpoint see the [Async Upload Endpoint Example](/api-reference/endpoint/async-fetch).
+

--- a/api-reference/endpoint/async-fetch.mdx
+++ b/api-reference/endpoint/async-fetch.mdx
@@ -1,4 +1,4 @@
 ---
-title: 'Fetch'
+title: 'Async Fetch'
 openapi: 'POST /async/fetch'
 ---

--- a/api-reference/endpoint/async-upload.mdx
+++ b/api-reference/endpoint/async-upload.mdx
@@ -1,4 +1,4 @@
 ---
-title: 'Upload'
+title: 'Async Upload'
 openapi: 'POST /async/upload'
 ---

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -7,8 +7,27 @@ description: 'API Reference for directly calling AnyParser API'
 
 The AnyParser API is a real-time parser designed to extract content from various file formats, including PDFs and DOCX files. The API accepts file content encoded in base64, processes it, and returns the parsed data in markdown format.
 
+### File formats
+The SDK processes the following types of files:
+- **PDF files**
+- **Office files**: `docx`, `pptx`
+- **Image files**: `png`, `jpg`, `jpeg`
+
+### Features
+The AnyParser API has the following features:
+- Full content parsing
+- Key-value extraction
+
+### Sync vs Async API
+In the AnyParser API, you can use either the sync or async endpoints.
+- [**Sync API**](/api-reference/sync-endpoints): This is a blocking API that will return the results of the parse or extraction. It will time out after 30 seconds. This works well for shorter and simple files.
+- [**Async API**](/api-reference/async-endpoints): This is an asynchronous API that will return a file ID. You can use this file ID to fetch the results of the extraction at a later time. Consider using if you have longer or more complex files.
+
 ### API Base URL
 ```python
 https://public-api.cambio-ai.com
 ```
+
+### SDK
+If you'd prefer to use the AnyParser SDK, please refer to the [SDK Reference](/sdk-reference/)
 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -13,9 +13,18 @@
       "url": "https://public-api.cambio-ai.com"
     }
   ],
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      }
+    }
+  },
   "security": [
     {
-      "bearerAuth": []
+      "apiKeyAuth": []
     }
   ],
   "paths": {
@@ -210,7 +219,23 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {}
+                "properties": {
+                  "file_name": {
+                    "type": "string",
+                    "description": "The name of the file to be uploaded."
+                  },
+                  "process_type": {
+                    "type": "string",
+                    "enum": ["file", "table", "json", "file_refined_quick", "extract_pii"],
+                    "description": "The type of processing to apply to the uploaded file. Default is `file`."
+                  },
+                  "extract_args": {
+                    "type": "object",
+                    "description": "Arguments for extraction processing.",
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["file_name", "process_type"]
               }
             }
           }

--- a/api-reference/sync-endpoints.mdx
+++ b/api-reference/sync-endpoints.mdx
@@ -1,0 +1,16 @@
+---
+title: 'Sync API Endpoints'
+description: 'API Reference for the synchronous functions of the AnyParser API'
+---
+
+## Overview
+The `AnyParser` API has synchronous endpoints for its parsing and extraction features. These are a blocking and will return the results of the parse or extraction. It will time out after 30 seconds. This works well for shorter and simple files.
+
+Here's an overview of the endpoints:
+| Endpoint        | Description                                       |
+|-----------------|---------------------------------------------------|
+| [/extract](/api-reference/endpoint/extract)      | Parses the entire content of a file into markdown |
+| [/json/extract](/api-reference/endpoint/json-extract)  | Extracts key-value information from a file        |
+| [/query](/api-reference/endpoint/query)  | Query to see how many pages you have left for your api key      |
+
+

--- a/mint.json
+++ b/mint.json
@@ -67,17 +67,24 @@
     {
       "group": "API Documentation",
       "pages": [
-        "api-reference/introduction"
+        "api-reference/introduction",
+        "api-reference/sync-endpoints",
+        "api-reference/async-endpoints"
       ]
     },
     {
-      "group": "Endpoint Examples",
+      "group": "Sync Endpoint Examples",
       "pages": [
         "api-reference/endpoint/extract",
         "api-reference/endpoint/json-extract",
-        "api-reference/endpoint/query",
-        "api-reference/endpoint/upload",
-        "api-reference/endpoint/fetch"
+        "api-reference/endpoint/query"
+      ]
+    },
+    {
+      "group": "Async Endpoint Examples",
+      "pages": [
+        "api-reference/endpoint/async-upload",
+        "api-reference/endpoint/async-fetch"
       ]
     },
     {


### PR DESCRIPTION
- Update API Reference introduction to give overview on sync and async endpoints
- update openapi.json to correctly document /async/upload with `process_type` parameter
- Add `sync-endpoints.mdx` and `async-endpoints.mdx` pages to give overview of sync and async endpoints for API